### PR TITLE
Enable to run in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class Table {
    * @alias module:table-layout
    */
   constructor (data, options) {
-    let ttyWidth = (process && (process.stdout.columns || process.stderr.columns)) || 0
+    let ttyWidth = (process && process.stdout && (process.stdout.columns || process.stderr.columns)) || 0
 
     /* Windows quirk workaround  */
     if (ttyWidth && os.platform() === 'win32') ttyWidth--


### PR DESCRIPTION
I am gonna to run command-line-usage in browser environment with help of webpack. Unfortunately, webpack 4 polyfill for `process` module does not support `process.stdout`. I suggest check if that property is available, before attempt to use it.

