### PR TITLE
Add a `transform` property to each column to transform a cell's value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 out
 .coveralls.yml
 coverage
+node_modules

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Returns the input data as a text table.
 | [padding] | <code>object</code> | padding options |
 | [padding.left] | <code>string</code> | a string to pad the left of each cell (default: `' '`) |
 | [padding.right] | <code>string</code> | a string to pad the right of each cell (default: `' '`) |
+| [transform] | <code>function</code> | a function which will be ran for each value of this column. Transforming it. |
 
 
 * * *

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -72,7 +72,11 @@ class Cell {
 
   get value () {
     let cellValue = _value.get(this);
-    if (typeof cellValue === 'function') cellValue = cellValue.call(_column.get(this));
+    let column = _column.get(this);
+    if (column.transform !== undefined) {
+      cellValue = column.transform.call(column, cellValue);
+    }
+    if (typeof cellValue === 'function') cellValue = cellValue.call(column);
     if (cellValue === undefined) {
       cellValue = '';
     } else {
@@ -468,6 +472,8 @@ class Column {
     if (t$1.isDefined(column.contentWrappable)) this.contentWrappable = column.contentWrappable;
     if (t$1.isDefined(column.contentWidth)) this.contentWidth = column.contentWidth;
     if (t$1.isDefined(column.minContentWidth)) this.minContentWidth = column.minContentWidth;
+    
+    if (t$1.isDefined(column.transform)) this.transform = column.transform;
     this.padding = column.padding || { left: ' ', right: ' ' };
     this.generatedWidth = null;
   }
@@ -1198,10 +1204,13 @@ class Table {
         if (optionColumn.maxWidth) column.maxWidth = optionColumn.maxWidth;
         if (optionColumn.minWidth) column.minWidth = optionColumn.minWidth;
         if (optionColumn.noWrap) column.noWrap = optionColumn.noWrap;
+
         if (optionColumn.break) {
           column.break = optionColumn.break;
           column.contentWrappable = true;
         }
+
+        if (optionColumn.transform) column.transform = optionColumn.transform;
       }
     });
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -70,7 +70,11 @@ class Cell {
 
   get value () {
     let cellValue = _value.get(this);
-    if (typeof cellValue === 'function') cellValue = cellValue.call(_column.get(this));
+    let column = _column.get(this);
+    if (column.transform !== undefined) {
+      cellValue = column.transform.call(column, cellValue);
+    }
+    if (typeof cellValue === 'function') cellValue = cellValue.call(column);
     if (cellValue === undefined) {
       cellValue = '';
     } else {
@@ -466,6 +470,8 @@ class Column {
     if (t$1.isDefined(column.contentWrappable)) this.contentWrappable = column.contentWrappable;
     if (t$1.isDefined(column.contentWidth)) this.contentWidth = column.contentWidth;
     if (t$1.isDefined(column.minContentWidth)) this.minContentWidth = column.minContentWidth;
+    
+    if (t$1.isDefined(column.transform)) this.transform = column.transform;
     this.padding = column.padding || { left: ' ', right: ' ' };
     this.generatedWidth = null;
   }
@@ -1196,10 +1202,13 @@ class Table {
         if (optionColumn.maxWidth) column.maxWidth = optionColumn.maxWidth;
         if (optionColumn.minWidth) column.minWidth = optionColumn.minWidth;
         if (optionColumn.noWrap) column.noWrap = optionColumn.noWrap;
+
         if (optionColumn.break) {
           column.break = optionColumn.break;
           column.contentWrappable = true;
         }
+
+        if (optionColumn.transform) column.transform = optionColumn.transform;
       }
     });
 

--- a/index.mjs
+++ b/index.mjs
@@ -94,10 +94,13 @@ class Table {
         if (optionColumn.maxWidth) column.maxWidth = optionColumn.maxWidth
         if (optionColumn.minWidth) column.minWidth = optionColumn.minWidth
         if (optionColumn.noWrap) column.noWrap = optionColumn.noWrap
+
         if (optionColumn.break) {
           column.break = optionColumn.break
           column.contentWrappable = true
         }
+
+        if (optionColumn.transform) column.transform = optionColumn.transform
       }
     })
 
@@ -191,5 +194,6 @@ function padCell (cellValue, padding, width) {
  * @property [padding] {object} - padding options
  * @property [padding.left] {string} - a string to pad the left of each cell (default: `' '`)
  * @property [padding.right] {string} - a string to pad the right of each cell (default: `' '`)
+ * @property [transform] {function} - a function which will be ran for each value of this column. Transforming it.
  */
 export default Table

--- a/lib/cell.mjs
+++ b/lib/cell.mjs
@@ -13,7 +13,11 @@ class Cell {
 
   get value () {
     let cellValue = _value.get(this)
-    if (typeof cellValue === 'function') cellValue = cellValue.call(_column.get(this))
+    let column = _column.get(this);
+    if (column.transform !== undefined) {
+      cellValue = column.transform.call(column, cellValue)
+    }
+    if (typeof cellValue === 'function') cellValue = cellValue.call(column)
     if (cellValue === undefined) {
       cellValue = ''
     } else {

--- a/lib/column.mjs
+++ b/lib/column.mjs
@@ -29,6 +29,8 @@ class Column {
     if (t.isDefined(column.contentWrappable)) this.contentWrappable = column.contentWrappable
     if (t.isDefined(column.contentWidth)) this.contentWidth = column.contentWidth
     if (t.isDefined(column.minContentWidth)) this.minContentWidth = column.minContentWidth
+    
+    if (t.isDefined(column.transform)) this.transform = column.transform
     this.padding = column.padding || { left: ' ', right: ' ' }
     this.generatedWidth = null
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "typical": "^7.0.0",
         "wordwrapjs": "^5.0.2"
       },
+      "bin": {
+        "table-layout": "bin/cli.mjs"
+      },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.0.0",
         "coveralls": "^3.1.1",

--- a/test/fixture/fixture.mjs
+++ b/test/fixture/fixture.mjs
@@ -10,6 +10,22 @@ export const primatives = {
   ]
 }
 
+export const transformTest = {
+  options: {
+    columns: [{
+      name:"two",
+      transform: function(two) {
+        return two + 2;
+      }
+    }]
+  },
+  data: [
+    { one: 'a', two: 3 },
+    { one: 'b', two: 5 },
+    { one: 'c', two: 7 },
+  ]
+}
+
 export const simpleMaxWidth = {
   options: {
     maxWidth: 40,

--- a/test/table.mjs
+++ b/test/table.mjs
@@ -2,7 +2,7 @@ import TestRunner from 'test-runner'
 import os from 'os'
 import assert from 'assert'
 import Table from '../index.mjs'
-import { simpleMaxWidth, primatives } from './fixture/fixture.mjs'
+import { simpleMaxWidth, primatives, transformTest } from './fixture/fixture.mjs'
 const a = assert.strict
 
 const tom = new TestRunner.Tom()
@@ -100,6 +100,17 @@ tom.test('column options', function () {
 
   const table = new Table(data, options)
   a.deepStrictEqual(table.renderLines(), expected)
+})
+
+tom.test('Column Transform', function () {
+  const result = [
+    ' a  5 ',
+    ' b  7 ',
+    ' c  9 '
+  ].join(os.EOL) + os.EOL
+
+  const table = new Table(transformTest.data, transformTest.options)
+  a.strictEqual(table.toString(), result)
 })
 
 export default tom


### PR DESCRIPTION
Sometimes a cell's value might need transforming before display. This can happen for complex objects where `toString` or `String(value)` is not enough.

This adds an optional `transform` property to each `columnOptions` object. When specified this will run the provided function to mutate the value for display.

example:
```
columns: [{
	name:"two",
	transform: function(two) {
		return two + 2;
	}
}]
```

would add two to the column value for the column named "two".

You can see more in the added test.